### PR TITLE
Add a layer 3 fib notifier to the poc

### DIFF
--- a/bpf-notifier/README.org
+++ b/bpf-notifier/README.org
@@ -3,6 +3,8 @@
 PoC to explore using a BPF program attached to ~fentry/call_switchdev_notifiers~ to capture
 switchdev notifier messages and forward the info to user space via a BPF ring buffer.
 
+** Usage
+
 Run the notifier:
 
 #+begin_src sh :results output
@@ -12,12 +14,22 @@ $ sudo ./notifier
 In a separate terminal, create a bridge:
 
 #+begin_src sh :results output
-$ sudo ip link add name br0 type bridge
+sudo ip link add name br0 type bridge
+sudo ip link set up dev br0
+sudp ip route add 10.10.10.0/24 dev br0
 #+end_src
 
-You should see a notifier event in the first terminal:
+You should see notifier events in the first terminal:
 
 #+begin_src sh :results output
-$ sudo ./notifier
-notifier event id=3, mac=3a:d:d0:de:f:a8, name=br0
+sudo ./notifier
+switchdev event id=3, mac=e:19:b8:ab:f9:55, name=br0
+fib event id=0, dest=fe80::c19:b8ff:feab:f955/128
+fib event id=0, dest=0.10.10.10/24
+#+end_src
+
+** Cleanup
+
+#+begin_src sh :results output
+sudo ip link del name br0 type bridge
 #+end_src

--- a/bpf-notifier/notifier.bpf.c
+++ b/bpf-notifier/notifier.bpf.c
@@ -8,6 +8,7 @@
 #include <bpf/bpf_core_read.h>
 #include <linux/if.h>
 #include <linux/if_ether.h>
+#include <linux/in6.h>
 
 #include "notifier.h"
 
@@ -31,10 +32,53 @@ struct switchdev_notifier_fdb_info {
 	     offloaded:1;
 } __attribute__((preserve_access_index));;
 
+
+struct net {
+	int ifindex;
+} __attribute__((preserve_access_index));
+
+enum fib_event_type {
+	FIB_EVENT_ENTRY_REPLACE,
+	FIB_EVENT_ENTRY_APPEND,
+	FIB_EVENT_ENTRY_ADD,
+	FIB_EVENT_ENTRY_DEL,
+	FIB_EVENT_RULE_ADD,
+	FIB_EVENT_RULE_DEL,
+	FIB_EVENT_NH_ADD,
+	FIB_EVENT_NH_DEL,
+	FIB_EVENT_VIF_ADD,
+	FIB_EVENT_VIF_DEL,
+};
+
+struct fib_notifier_info {
+	int family;
+} __attribute__((preserve_access_index));
+
+struct fib_entry_notifier_info {
+	struct fib_notifier_info info; /* must be first */
+	__u32 dst;
+	int dst_len;
+} __attribute__((preserve_access_index));
+
+struct rt6key {
+	struct in6_addr addr;
+	int plen;
+} __attribute__((preserve_access_index));
+
+struct fib6_info {
+	struct rt6key fib6_dst;
+} __attribute__((preserve_access_index));
+
+struct fib6_entry_notifier_info {
+	struct fib_notifier_info info; /* must be first */
+	struct fib6_info *rt;
+} __attribute__((preserve_access_index));
+
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
 	__uint(max_entries, 4096);
 } notifier_events SEC(".maps");
+
 
 SEC("fentry/call_switchdev_notifiers")
 int BPF_PROG(switchdev_notifier,
@@ -48,6 +92,7 @@ int BPF_PROG(switchdev_notifier,
 	if (!event)
 		return 0;
 
+	event->type = N_SWITCHDEV;
 	event->val = val;
 
 	struct switchdev_notifier_fdb_info* fdb =
@@ -55,10 +100,41 @@ int BPF_PROG(switchdev_notifier,
 	const unsigned char *addr =
 		BPF_CORE_READ(fdb, addr);
 	bpf_probe_read_kernel(event->mac, ETH_ALEN, addr);
-
 	bpf_probe_read_kernel(event->name, IFNAMSIZ, dev->name);
 
-        bpf_ringbuf_submit(event, 0);
+	bpf_ringbuf_submit(event, 0);
+	return 0;
+}
+
+SEC("fentry/call_fib_notifiers")
+int BPF_PROG(fib_notifier,
+	     struct net *net,
+	     enum fib_event_type event_type,
+	     struct fib_notifier_info *info)
+{
+	struct notifier_event *event =
+		bpf_ringbuf_reserve(&notifier_events,
+				    sizeof(struct notifier_event), 0);
+	if (!event)
+		return 0;
+
+	event->type = N_FIB;
+	event->val = event_type;
+	event->family = BPF_CORE_READ(info, family);
+
+	if (event->family == AF_INET) {
+		struct fib_entry_notifier_info *fib =
+			(struct fib_entry_notifier_info *)info;
+		event->ipv4_dest = BPF_CORE_READ(fib, dst);
+		event->dest_len = BPF_CORE_READ(fib, dst_len);
+	} else if (event->family == AF_INET6) {
+		struct fib6_entry_notifier_info *fib =
+			(struct fib6_entry_notifier_info *)info;
+		event->ipv6_dest = BPF_CORE_READ(fib, rt, fib6_dst.addr);
+		event->dest_len = BPF_CORE_READ(fib, rt, fib6_dst.plen);
+	}
+
+	bpf_ringbuf_submit(event, 0);
 	return 0;
 }
 

--- a/bpf-notifier/notifier.h
+++ b/bpf-notifier/notifier.h
@@ -4,10 +4,20 @@
 #ifndef __NOTIFIER_H
 #define __NOTIFIER_H
 
+enum notifier_event_type {
+	N_SWITCHDEV,
+	N_FIB
+};
+
 struct notifier_event {
+	enum notifier_event_type type;
+	int family;
 	unsigned long val;
 	char mac[ETH_ALEN];
 	__u8 name[IFNAMSIZ];
+	__u32 ipv4_dest;
+	struct in6_addr ipv6_dest;
+	int dest_len;
 };
 
 #endif /* __NOTIFIER_H */


### PR DESCRIPTION
Both fib and switchdev share the same ring buffer with the same notifier event structure, just as proof of concept. Could use separate ring buffers or separate structs on the same ring buffer.